### PR TITLE
feat(attendance): deduct break (break_start/end) without rounding; cl…

### DIFF
--- a/app/controllers/attendance/daily_controller.rb
+++ b/app/controllers/attendance/daily_controller.rb
@@ -14,7 +14,7 @@ module Attendance
         },
         totals: {
           work: attendance_summary.work_minutes,
-          break: 0,
+          break: attendance_summary.break_minutes,
           overtime: 0,
           night: 0,
           holiday: 0

--- a/spec/requests/attendance/my_daily_spec.rb
+++ b/spec/requests/attendance/my_daily_spec.rb
@@ -77,5 +77,19 @@ RSpec.describe "Attendance::Daily", type: :request do
       expect(body["actual"]["end"]).to include("2025-08-21T18:00")
       expect(body["totals"]["work"]).to eq(0)
     end
+
+    it "returns break minutes in totals when breaks exist" do
+      TimeEntry.create!(user_id: 1, kind: :clock_in,  happened_at: Time.zone.parse("2025-08-23 09:00"), source: "web")
+      TimeEntry.create!(user_id: 1, kind: :break_start, happened_at: Time.zone.parse("2025-08-23 12:00"), source: "web")
+      TimeEntry.create!(user_id: 1, kind: :break_end,   happened_at: Time.zone.parse("2025-08-23 12:30"), source: "web")
+      TimeEntry.create!(user_id: 1, kind: :clock_out, happened_at: Time.zone.parse("2025-08-23 18:00"), source: "web")
+
+      get "/v1/attendance/my/daily", params: { user_id: 1, date: "2025-08-23" }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["totals"]["break"]).to eq(30)
+      expect(body["totals"]["work"]).to  eq(540 - 30)
+      expect(body["status"]).to eq("closed")
+    end
   end
 end

--- a/spec/services/attendance/calculator_spec.rb
+++ b/spec/services/attendance/calculator_spec.rb
@@ -49,4 +49,36 @@ RSpec.describe Attendance::Calculator do
     expect(r.start_at.iso8601).to include("08:55")
     expect(r.end_at.iso8601).to include("18:05")
   end
+
+  it "deducts break minutes (no rounding)" do
+    date = Date.parse("2025-08-21")
+    TimeEntry.create!(user_id: 1, kind: :clock_in,  happened_at: Time.zone.parse("2025-08-21 09:00"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :break_start, happened_at: Time.zone.parse("2025-08-21 12:00"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :break_end,   happened_at: Time.zone.parse("2025-08-21 12:45"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :clock_out, happened_at: Time.zone.parse("2025-08-21 18:00"), source: "web")
+
+    r = described_class.summarize_day(user_id: 1, data: date)
+    expect(r.work_minutes).to  eq(540 - 45) # 09:00-18:00=480分から休憩45分を引く
+    expect(r.break_minutes).to eq(45)
+    expect(r.status).to eq("closed")
+  end
+
+  it "ignores unmatched break pairs and clips break within work range" do
+    date = Date.parse("2025-08-22")
+    # 勤務 10:00-19:00
+    TimeEntry.create!(user_id: 1, kind: :clock_in,  happened_at: Time.zone.parse("2025-08-22 10:00"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :clock_out, happened_at: Time.zone.parse("2025-08-22 19:00"), source: "web")
+    # 勤務外の休憩（前）→ クリップされて0
+    TimeEntry.create!(user_id: 1, kind: :break_start, happened_at: Time.zone.parse("2025-08-22 09:30"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :break_end,   happened_at: Time.zone.parse("2025-08-22 09:50"), source: "web")
+    # 休憩ペア1（勤務内）
+    TimeEntry.create!(user_id: 1, kind: :break_start, happened_at: Time.zone.parse("2025-08-22 12:10"), source: "web")
+    TimeEntry.create!(user_id: 1, kind: :break_end,   happened_at: Time.zone.parse("2025-08-22 12:40"), source: "web")
+    # 片割れ（endのみ）→ 無視
+    TimeEntry.create!(user_id: 1, kind: :break_end,   happened_at: Time.zone.parse("2025-08-22 15:00"), source: "web")
+
+    r = described_class.summarize_day(user_id: 1, data: date)
+    expect(r.break_minutes).to eq(30)           # 12:10-12:40 のみ有効
+    expect(r.work_minutes).to eq(540 - 30)      # 10:00-19:00=540 から30分控除
+  end
 end


### PR DESCRIPTION
## 概要 (Overview)

勤怠サマリ機能に、休憩時間の計算と実働時間からの控除機能を追加します。

`break_start`と`break_end`の打刻を元に休憩時間を算出し、`totals`オブジェクトに`break`として含め、`work`（実働時間）からその分を差し引きます。

## 変更内容 (Changes)

- **Service Class (`Attendance::Calculator`):**
  - `summarize_day`メソッドに、休憩時間を計算するロジックを追加しました。
  - 休憩開始/終了のペアを正しく処理し、勤務時間外の休憩を無視する（クリッピングする）ための`sum_break_minutes_within`ヘルパーメソッドを新規に実装しました。
  - 計算結果を返す`Result`オブジェクトに`:break_minutes`を追加しました。
- **Testing (`spec/services/attendance/calculator_spec.rb`):**
  - 休憩時間が正しく計算・控除されることを確認するテストケースを追加しました。
  - 休憩打刻がペアになっていない場合や、勤務時間外の休憩が正しく無視されるかといった、複雑なケースを網羅するテストも追加しています。
- **Request Spec (`spec/requests/attendance/my_daily_spec.rb`):**
  - APIのレスポンスに`totals.break`が含まれ、`totals.work`が休憩時間分だけ減っていることを確認するテストケースを追加しました。

## 変更前の挙動との比較

- **変更前:** `break_start`/`break_end`の打刻は完全に無視されていました。`totals.work`は単純に`(最後の退勤 - 最初の出勤)`の時間でした。
- **変更後:** `break_start`/`break_end`のペアから休憩時間を計算し、`totals.work`は`(最後の退勤 - 最初の出勤) - 休憩時間`となります。レスポンスの`totals`オブジェクトに`break`キーが追加されます。

## 確認方法 (How to Verify)

1. `rails s` でサーバーを起動します。
2. 以下のコマンドブロックをターミナルにコピー＆ペーストし、休憩時間が正しく計算・控除されていることを確認してください。

   **ケース1: 休憩ありの勤務**
   ```bash
   # データ作成 (09:00-18:00勤務, 12:00-12:30休憩)
   curl -X POST http://localhost:3000/v1/timeclock/time_entries -d 'user_id=1&kind=clock_in&happened_at=2025-08-26T09:00:00+09:00&source=web'
   curl -X POST http://localhost:3000/v1/timeclock/time_entries -d 'user_id=1&kind=break_start&happened_at=2025-08-26T12:00:00+09:00&source=web'
   curl -X POST http://localhost:3000/v1/timeclock/time_entries -d 'user_id=1&kind=break_end&happened_at=2025-08-26T12:30:00+09:00&source=web'
   curl -X POST http://localhost:3000/v1/timeclock/time_entries -d 'user_id=1&kind=clock_out&happened_at=2025-08-26T18:00:00+09:00&source=web'
   
   # サマリ取得
   curl "http://localhost:3000/v1/attendance/my/daily?user_id=1&date=2025-08-26"
   # => "work":510, "break":30, "status":"closed" が返ってくることを確認