### PR TITLE
feat(auth): JWT login + /auth/me + /v1/attendance/me/daily; token-awa…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,9 @@ gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 
+gem "jwt"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -110,6 +111,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
+    jwt (3.1.2)
+      base64
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -334,9 +337,11 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   debug
+  jwt
   kamal
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,30 @@
 class ApplicationController < ActionController::API
+   attr_reader :current_user
+
+  private
+
+  def authenticate!
+    header = request.headers["Authorization"]
+    return render json: { error: "missing_token" }, status: :unauthorized if header.blank?
+
+    token = header.split(" ").last
+    payload = JsonWebToken.decode(token)
+    @current_user = User.find(payload["sub"])
+  rescue JWT::ExpiredSignature
+    render json: { error: "token_expired" }, status: :unauthorized
+  rescue StandardError
+    render json: { error: "invalid_token" }, status: :unauthorized
+  end
+
+  # 認証は不要だが、トークンがあれば current_user をセット（POST打刻で使う）
+  def set_current_user_if_token_present
+    header = request.headers["Authorization"]
+    return if header.blank?
+
+    token = header.split(" ").last
+    payload = JsonWebToken.decode(token)
+    @current_user = User.find(payload["sub"])
+  rescue StandardError
+    # 何もしない（任意トークン）
+  end
 end

--- a/app/controllers/attendance/daily_controller.rb
+++ b/app/controllers/attendance/daily_controller.rb
@@ -23,5 +23,31 @@ module Attendance
         status: attendance_summary.status
       }
     end
+
+    def me
+      authenticate!
+      date = begin
+        Date.parse(params[:date].presence || Date.today.to_s)
+      rescue ArgumentError
+        Date.current
+      end
+
+      r = Attendance::Calculator.summarize_day(user_id: current_user.id, date: date)
+      render json: {
+        date: r.date.to_s,
+        actual: {
+          start: r.start_at&.iso8601,
+          end: r.end_at&.iso8601
+        },
+        totals: {
+          work: r.work_minutes,
+          break: r.break_minutes,
+          overtime: 0,
+          night: 0,
+          holiday: 0
+        },
+        status: r.status
+      }
+    end
   end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,18 @@
+class AuthController < ApplicationController
+  # POST /auth/login
+  def login
+    user = User.find_by(email: params[:email])
+    if user&.authenticate(params[:password])
+      token = JsonWebToken.encode({ sub: user.id, exp: 24.hours.from_now.to_i })
+      render json: { token: token, user: { id: user.id, email: user.email, name: user.name } }
+    else
+      render json: { error: "invalid_credentials" }, status: :unauthorized
+    end
+  end
+
+  # GET /auth/me
+  def me
+    authenticate!
+    render json: { id: current_user.id, email: current_user.email, name: current_user.name }
+  end
+end

--- a/app/controllers/timeclock/time_entries_controller.rb
+++ b/app/controllers/timeclock/time_entries_controller.rb
@@ -1,7 +1,13 @@
 module Timeclock
   class TimeEntriesController < ApplicationController
+    before_action :set_current_user_if_token_present, only: [ :create ]
+
     def create
-      entry = TimeEntry.new(time_entry_params)
+      attrs = time_entry_params.to_h
+      attrs[:user_id] ||= current_user&.id
+
+      entry = TimeEntry.new(attrs)
+
       if entry.save
         render json: entry, status: :created
       else

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,0 +1,9 @@
+module JsonWebToken
+  def self.encode(payload)
+    JWT.encode(payload, Rails.application.secret_key_base, "HS256")
+  end
+
+  def self.decode(token)
+    JWT.decode(token, Rails.application.secret_key_base, true, { algorithm: "HS256" }).first
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   has_many :time_entries
   validates :email, presence: true
+
+  has_secure_password
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,6 @@ module KintaiApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.autoload_paths << Rails.root.join("app/lib")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get :health, to: "health_checks#index"
 
+  post "/auth/login", to: "auth#login"
+  get "/auth/me", to: "auth#me"
+
   scope :v1 do
     namespace :timeclock do
       resources :time_entries, only: [ :index, :create ]
@@ -8,6 +11,7 @@ Rails.application.routes.draw do
 
     namespace :attendance do
       get "my/daily", to: "daily#show"
+      get "me/daily", to: "daily#me"
     end
   end
 end

--- a/db/migrate/20250902105159_add_password_digest_to_users.rb
+++ b/db/migrate/20250902105159_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_02_085618) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_02_105159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_02_085618) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "password_digest"
     t.index ["email"], name: "index_users_on_email"
   end
 


### PR DESCRIPTION
## 概要 (Overview)

APIのセキュリティを向上させるため、JWT (JSON Web Token) を用いた認証機能を実装します。

これにより、これまでの誰でもアクセス可能だった状態から、メールアドレスとパスワードでログインし、発行されたトークンを提示したユーザーのみが操作できる、安全なAPIに変わります。

## 変更内容 (Changes)

* **Gem:**
    * `Gemfile`に`jwt` gemを追加しました。
    * パスワードを安全に扱うため、`bcrypt` gemを有効化しました。

* **Database:**
    * `users`テーブルに、パスワードを暗号化して保存するための`password_digest`カラムを追加するマイグレーションを作成しました。

* **Model:**
    * `User`モデルに`has_secure_password`を追加し、パスワード認証機能を有効化しました。

* **Lib:**
    * `app/lib`ディレクトリを新設し、JWTトークンの生成(encode)と検証(decode)を行う`JsonWebToken`ユーティリティモジュールを配置しました。
    * `config/application.rb`に`app/lib`をオートロードパスへ追加しました。

* **Controller:**
    * `ApplicationController`に、トークンを検証して`@current_user`を設定する`authenticate!`などの認証ヘルパーメソッドを追加しました。
    * ログイン処理とトークン発行を行う`AuthController`を新規作成しました。
    * `TimeEntriesController`と`DailyController`を修正し、トークンを使って認証されたユーザーの操作のみを受け付けるように変更しました。

* **Routing:**
    * ログイン (`/auth/login`)、本人情報確認 (`/auth/me`)、そしてトークンを使った本人サマリ取得 (`/v1/attendance/me/daily`) のための新しいルートを追加しました。

## 確認方法 (How to Verify)

1.  `rails s` でサーバーを起動します。
2.  以下のコマンドブロックをターミナルにコピー＆ペーストし、順番に実行してください。

    **ステップ1: テストユーザーにパスワードを設定する**
    ```bash
    # (id:1 のユーザーは既に存在するので、パスワードだけを設定します)
    bin/rails runner 'u=User.find(1); u.password="pass1234"; u.save!'
    ```

    **ステップ2: ログインしてJWTトークンを取得する**
    ```bash
    # ログインAPIを叩き、返ってきたJSONからトークンをコピーします
    curl -X POST http://localhost:3000/auth/login \
      -d 'email=demo@example.com&password=pass1234'
    ```

    **ステップ3: 取得したトークンを使って、認証が必要なAPIを試す**
    ```bash
    # ターミナルでTOKEN変数を設定 (取得したトークンを貼り付け)
    TOKEN="ここにステップ2で取得したトークンを貼り付けてください"

    # 自分の情報を取得する
    curl -H "Authorization: Bearer $TOKEN" http://localhost:3000/auth/me

    # 自分の勤怠サマリを取得する
    curl -H "Authorization: Bearer $TOKEN" "http://localhost:3000/v1/attendance/me/daily?date=2025-09-02"

    # 自分の打刻を作成する (user_idは不要)
    curl -H "Authorization: Bearer $TOKEN" \
      -X POST http://localhost:3000/v1/timeclock/time_entries \
      -d 'kind=clock_in&happened_at=2025-09-02T10:00:00+09:00&source=web'
    ```

## 備考 (Notes)

* 後方互換性のため、既存の`user_id`をパラメータに含むAPI (`/v1/attendance/my/daily` と `/v1/timeclock/time_entries`) は、ひとまずそのまま利用可能にしてあります。
* 今後、これらの古いAPIを削除し、完全にトークンベースの認証に移行する予定です。