### PR TITLE
feat(users): add base_hourly_yen with non-negative DB constraint

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
 
   has_secure_password
   enum :role, { employee: 0, admin: 1 }
+
+  validates :base_hourly_wage, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/db/migrate/20250904115859_add_base_hourly_yen_to_users.rb
+++ b/db/migrate/20250904115859_add_base_hourly_yen_to_users.rb
@@ -1,0 +1,9 @@
+class AddBaseHourlyYenToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :base_hourly_wage, :integer, null: false, default: 0
+
+    add_check_constraint :users,
+    "base_hourly_wage >= 0",
+    name: "base_hourly_wage_non_negative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_03_101001) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_04_115859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,8 +34,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_03_101001) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.integer "role", default: 0, null: false
+    t.integer "base_hourly_wage", default: 0, null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["role"], name: "index_users_on_role"
+    t.check_constraint "base_hourly_wage >= 0", name: "base_hourly_wage_non_negative"
   end
 
   add_foreign_key "time_entries", "users"


### PR DESCRIPTION
# feat: ユーザーモデルに時給(base_hourly_wage)を追加

## 概要

今後の人件費計算機能の実装に向けた第一歩として、Userモデルに時給を保存するためのカラム `base_hourly_wage` を追加します。

## 変更内容

- **DBマイグレーションの追加**
  - `users`テーブルに `base_hourly_wage` カラム（`integer`型）を追加しました。
  - データ不整合を防ぐため、以下の制約を設定しています。
    - `NOT NULL`
    - `DEFAULT 0`

- **DBチェック制約の追加**
  - `base_hourly_wage` が `0` 以上の値であること を保証するため、データベースレベルでのチェック制約 `chk_users_base_hourly_nonneg` を追加しました。

- **モデルバリデーションの追加**
  - `User`モデルに、`base_hourly_wage` が `0` 以上の整数であるかを検証するバリデーションを追加しました。これにより、アプリケーションレベルでも不正な値の保存を防ぎます。
