### PR TITLE
feat(payroll): add daily quote API (me/user) using base_hourly_wage a…

### DIFF
--- a/app/controllers/payroll/daily_quotes_controller.rb
+++ b/app/controllers/payroll/daily_quotes_controller.rb
@@ -1,0 +1,42 @@
+module Payroll
+  class DailyQuotesController < ApplicationController
+    before_action :authenticate!
+
+    def me
+      date = Date.parse(params[:date].presence || Date.today.to_s)
+      render json: quote_for(user_id: current_user.id, date: date)
+    end
+
+    def user
+      user_id = params.require(:user_id)
+      return render json: { error: "forbidden" }, status: :forbidden if current_user.employee? && current_user.id.to_s != user_id.to_s
+
+      date = Date.parse(params[:date].presence || Date.today.to_s)
+      render json: quote_for(user_id: user_id, date: date)
+    end
+
+    private
+
+    def quote_for(user_id:, date:)
+      attendance_summary = Attendance::Calculator.summarize_day(user_id: user_id, date: date)
+      base = User.find(user_id).base_hourly_wage.to_i
+
+      wage = ::Payroll::Calculator.daily_wage(
+        base: base,
+        work_minutes: attendance_summary.work_minutes,
+        night_minutes: attendance_summary.night_minutes
+      )
+
+      {
+        date: date.to_s,
+        user_id: user_id.to_i,
+        base_hourly_wage: base,
+        work_minutes: attendance_summary.work_minutes,
+        break_minutes: attendance_summary.break_minutes,
+        night_minutes: attendance_summary.night_minutes,
+        daily_wage: wage,
+        status: attendance_summary.status
+      }
+    end
+  end
+end

--- a/app/services/payroll/calculator.rb
+++ b/app/services/payroll/calculator.rb
@@ -1,0 +1,14 @@
+module Payroll
+  class Calculator
+    # 日給計算
+    # base: 時給（整数、円）
+    # work_minutes: 実勤務時間（休憩控除）
+    # night_minutes: 深夜該当分
+    # 戻り値: 日給（整数、円，1円未満切り捨て）
+    def self.daily_wage(base:, work_minutes:, night_minutes:)
+      normal = base * (work_minutes.to_f / 60.0)
+      night_bonus = (base * 0.25) * (night_minutes.to_f / 60.0)
+      (normal + night_bonus).floor
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,10 @@ Rails.application.routes.draw do
       get "my/daily", to: "daily#show"
       get "me/daily", to: "daily#me"
     end
+
+    namespace :payroll do
+      get "me/daily_quote", to: "daily_quotes#me"
+      get "user/daily_quote", to: "daily_quotes#user"
+    end
   end
 end

--- a/spec/requests/payroll/daily_quotes_spec.rb
+++ b/spec/requests/payroll/daily_quotes_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Payroll::DailyQuotes", type: :request do
+  let(:tz) { ActiveSupport::TimeZone["Asia/Tokyo"] }
+  let(:date) { Date.parse("2025-09-06") }
+
+  let!(:admin) do
+    User.find_or_create_by!(email: "admin@example.com") do |u|
+      u.password = "adminpass"
+      u.role = :admin
+      u.base_hourly_wage = 1200
+      u.name = "Admin"
+    end
+  end
+
+  let!(:emp) do
+    User.find_or_create_by!(email: "emp@example.com") do |u|
+      u.password = "emppass"
+      u.role = :employee
+      u.base_hourly_wage = 1100
+      u.name = "Emp"
+    end
+  end
+
+  def token_for(email:, password:)
+    post "/auth/login", params: { email:, password: }
+    JSON.parse(response.body)["token"]
+  end
+
+  it "returns daily quote for me" do
+    # 22:00-23:00（深夜60分）勤務
+    TimeEntry.create!(user_id: emp.id, kind: :clock_in,  happened_at: tz.parse("#{date} 22:00"), source: "spec")
+    TimeEntry.create!(user_id: emp.id, kind: :clock_out, happened_at: tz.parse("#{date} 23:00"), source: "spec")
+
+    t = token_for(email: "emp@example.com", password: "emppass")
+    get "/v1/payroll/me/daily_quote", params: { date: date.to_s }, headers: { "Authorization" => "Bearer #{t}" }
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["work_minutes"]).to eq(60)
+    expect(body["night_minutes"]).to eq(60)
+    # 1100円/h → 通常 1100 * 1h = 1100、夜間ボーナス 1100*0.25*1h = 275 → 合計 1375
+    expect(body["daily_wage"]).to eq(1375)
+  end
+
+  it "allows admin to view other user" do
+    t = token_for(email: "admin@example.com", password: "adminpass")
+    get "/v1/payroll/user/daily_quote", params: { user_id: emp.id, date: date.to_s }, headers: { "Authorization" => "Bearer #{t}" }
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## 概要
- 日次の給与見積りAPIを追加しました（保存なし）。
  - `GET /v1/payroll/me/daily_quote?date=`：本人
  - `GET /v1/payroll/user/daily_quote?user_id=&date=`：管理者

## 計算仕様
- 入力：`users.base_hourly_wage`、`Attendance::Calculator.summarize_day` の `work_minutes` / `night_minutes`
- 式：`wage = base * (work/60) + base*0.25 * (night/60)`（1円未満切捨て）
- 深夜帯は 22:00–05:00、1分単位（丸めなし）
- 退勤がないオープンシフトは集計しない（既存仕様に合わせる）

## 変更点
- `app/services/payroll/calculator.rb`：`daily_wage_yen` を追加
- `app/controllers/payroll/daily_quotes_controller.rb`：上記2エンドポイント
- ルーティング追加

## 認可
- どちらも認証必須
- `/user/daily_quote` は管理者のみ（従業員が他人分を指定した場合は 403）

## マイグレーション
- なし

## 動作確認
- curl で本人/管理者の両方のパスを確認
- 単体例：1100円/hで深夜60分 → 1375 円

## リスク/ロールバック
- 低。既存APIには影響なし。必要ならルートを一時的にコメントアウトで回避可能。
-