### PR TITLE
feat(payroll): add daily total API (admin) to sum per-user wages and …

### DIFF
--- a/app/controllers/payroll/daily_totals_controller.rb
+++ b/app/controllers/payroll/daily_totals_controller.rb
@@ -1,0 +1,53 @@
+module Payroll
+  class DailyTotalsController < ApplicationController
+    before_action :authenticate!
+    # 管理者のみアクセス可能
+    def show
+      return render json: { error: "forbidden" }, status: :forbidden unless current_user.admin?
+
+      date = Date.parse(params[:date].presence || Date.today.to_s)
+      tz = ActiveSupport::TimeZone["Asia/Tokyo"]
+      day_start = tz.parse("#{date} 00:00")
+      day_end = tz.parse("#{date} 23:59:59") + 1.second
+      range = day_start...(day_end - 1.second)
+
+      user_ids = TimeEntry.where(happened_at: range).distinct.pluck(:user_id) # その日の勤怠記録があるユーザーID一覧を取得(重複なし)
+      users = User.where(id: user_ids).select(:id, :name, :base_hourly_wage) # そのユーザーIDに対応するユーザー情報を取得
+
+      users_by_id = users.index_by(&:id) # ユーザーIDをキーとしたハッシュに変換
+
+      rows = []
+      total = 0
+
+      user_ids.each do |uid|
+        user = users_by_id[uid]
+        next unless user
+
+        attendance_summary = Attendance::Calculator.summarize_day(user_id: uid, date: date)
+        base = user.base_hourly_wage.to_i
+
+        wage = ::Payroll::Calculator.daily_wage(
+          base: base,
+          work_minutes: attendance_summary.work_minutes,
+          night_minutes: attendance_summary.night_minutes
+        )
+
+        rows << {
+          user_id: uid,
+          user_name: user.name,
+          base_hourly_wage: base,
+          work_minutes: attendance_summary.work_minutes,
+          break_minutes: attendance_summary.break_minutes,
+          night_minutes: attendance_summary.night_minutes,
+          daily_wage: wage
+        }
+        total += wage
+      end
+      render json: {
+        date: date.to_s,
+        rows: rows.sort_by { |row| row[:user_id] },
+        total_daily_wage: total
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     namespace :payroll do
       get "me/daily_quote", to: "daily_quotes#me"
       get "user/daily_quote", to: "daily_quotes#user"
+      get "daily_total", to: "daily_totals#show"
     end
   end
 end

--- a/spec/requests/payroll/daily_totals_spec.rb
+++ b/spec/requests/payroll/daily_totals_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "Payroll::DailyTotals", type: :request do
+  let(:tz) { ActiveSupport::TimeZone["Asia/Tokyo"] }
+  let(:date) { Date.parse("2025-09-06") }
+
+  let!(:admin) do
+    User.find_or_create_by!(email: "admin@example.com") do |u|
+      u.password = "adminpass"
+      u.role = :admin
+      u.base_hourly_wage = 1200
+      u.name = "管理者"
+    end
+  end
+
+  let!(:emp1) do
+    User.find_or_create_by!(email: "emp1@example.com") do |u|
+      u.password = "emppass1"
+      u.role = :employee
+      u.base_hourly_wage = 1100
+      u.name = "従業員A"
+    end
+  end
+
+  let!(:emp2) do
+    User.find_or_create_by!(email: "emp2@example.com") do |u|
+      u.password = "emppass2"
+      u.role = :employee
+      u.base_hourly_wage = 1300
+      u.name = "従業員B"
+    end
+  end
+
+  def token_for(email:, password:)
+    post "/auth/login", params: { email:, password: }
+    JSON.parse(response.body)["token"]
+  end
+
+  # 各テストケースの前に、データベースをクリーンな状態に保つ
+  before do
+    TimeEntry.destroy_all
+  end
+
+  it "admin can view the daily total of multiple users" do
+    # 従業員Aの打刻: 22:00-23:00（深夜60分）
+    TimeEntry.create!(user_id: emp1.id, kind: :clock_in,  happened_at: tz.parse("#{date} 22:00"), source: "spec")
+    TimeEntry.create!(user_id: emp1.id, kind: :clock_out, happened_at: tz.parse("#{date} 23:00"), source: "spec")
+
+    # 従業員Bの打刻: 9:00-10:00（通常60分）
+    TimeEntry.create!(user_id: emp2.id, kind: :clock_in,  happened_at: tz.parse("#{date} 09:00"), source: "spec")
+    TimeEntry.create!(user_id: emp2.id, kind: :clock_out, happened_at: tz.parse("#{date} 10:00"), source: "spec")
+
+    # 管理者としてログイン
+    t = token_for(email: "admin@example.com", password: "adminpass")
+
+    # daily_totalエンドポイントにリクエスト
+    get "/v1/payroll/daily_total", params: { date: date.to_s }, headers: { "Authorization" => "Bearer #{t}" }
+
+    # レスポンスの検証
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+
+    # 日付の検証
+    expect(body["date"]).to eq(date.to_s)
+
+    # rowsの検証
+    rows = body["rows"]
+    expect(rows.count).to eq(2)
+
+    # 従業員Aのデータ検証
+    emp1_data = rows.find { |row| row["user_id"] == emp1.id }
+    expect(emp1_data["work_minutes"]).to eq(60)
+    expect(emp1_data["night_minutes"]).to eq(60)
+    # 1100円/h → 通常 1100 * 1h = 1100、深夜ボーナス 1100*0.25*1h = 275 → 合計 1375
+    expect(emp1_data["daily_wage"]).to eq(1375)
+
+    # 従業員Bのデータ検証
+    emp2_data = rows.find { |row| row["user_id"] == emp2.id }
+    expect(emp2_data["work_minutes"]).to eq(60)
+    expect(emp2_data["night_minutes"]).to eq(0)
+    # 1300円/h → 通常 1300 * 1h = 1300 → 合計 1300
+    expect(emp2_data["daily_wage"]).to eq(1300)
+
+    # 合計金額の検証
+    total_wage = emp1_data["daily_wage"] + emp2_data["daily_wage"]
+    expect(body["total_daily_wage"]).to eq(total_wage)
+  end
+end


### PR DESCRIPTION
## 概要
管理者向けに **日別の人件費合計 API** を追加しました。

- `GET /v1/payroll/daily_total?date=YYYY-MM-DD`（adminのみ）

## 仕様
- 集計対象: 指定日の `time_entries` が存在するユーザーのみ
- 1ユーザーあたり:
  - `Attendance::Calculator.summarize_day` の `work_minutes` / `break_minutes` / `night_minutes` を採用
  - `users.base_hourly_wage` を使用
  - 賃金は `base * (work/60) + base*0.25 * (night/60)` を **1円未満切捨て**
  - `work_minutes == 0` は rows から除外
- レスポンス:
  ```json
  { "date": "YYYY-MM-DD",
    "rows": [{ "user_id": ..., "name": "...",
               "work_minutes": ..., "break_minutes": ..., "night_minutes": ...,
               "base_hourly_wage": ..., "wage_yen": ... }],
    "total_wage_yen": ... }