### PR TITLE
feat(sales): add daily sales table and admin APIs (GET/PUT upsert)

### DIFF
--- a/app/controllers/sales_controller.rb
+++ b/app/controllers/sales_controller.rb
@@ -1,0 +1,46 @@
+class SalesController < ApplicationController
+  before_action :authenticate!
+  before_action :require_admin!
+
+  # GET /v1/sales?date=YYYY-MM-DD
+  def show
+    date = parse_date!(params[:date])
+    return if performed?
+    sale = Sale.find_by(date: date)
+    render json: sale ? serialize(sale) : { date: date.to_s, amount_yen: nil, note: nil }
+  end
+
+  # PUT /v1/sales?date=YYYY-MM-DD
+  # body: amount_yen, note(optional)
+  def upsert
+    date = parse_date!(params[:date])
+    amount = params[:amount_yen].to_i
+    note = params[:note].presence
+
+    sale = Sale.find_or_initialize_by(date: date)
+    sale.amount_yen = amount
+    sale.note = note
+    if sale.save
+      render json: serialize(sale)
+    else
+      render json: { errors: sale.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def parse_date!(date_str)
+    Date.parse(date_str.presence || Date.today.to_s)
+  rescue ArgumentError
+    render json: { error: "invalid_date_format" }, status: :bad_request
+  end
+
+  def serialize(sale)
+    {
+      id: sale.id,
+      date: sale.date.to_s,
+      amount_yen: sale.amount_yen,
+      note: sale.note
+    }
+  end
+end

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -1,0 +1,4 @@
+class Sale < ApplicationRecord
+  validates :date, presence: true, uniqueness: true
+  validates :amount_yen, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,8 @@ Rails.application.routes.draw do
       get "user/daily_quote", to: "daily_quotes#user"
       get "daily_total", to: "daily_totals#show"
     end
+
+    get "sales", to: "sales#show"
+    put "sales", to: "sales#upsert"
   end
 end

--- a/db/migrate/20250906160228_create_sales.rb
+++ b/db/migrate/20250906160228_create_sales.rb
@@ -1,0 +1,13 @@
+class CreateSales < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sales do |t|
+      t.date :date, null: false
+      t.integer :amount_yen, null: false, default: 0
+      t.string :note
+
+      t.timestamps
+    end
+    add_index :sales, :date, unique: true
+    add_check_constraint :sales, "amount_yen >= 0", name: "chk_amount_nonneg"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_04_115859) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_06_160228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "sales", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "amount_yen", default: 0, null: false
+    t.string "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date"], name: "index_sales_on_date", unique: true
+    t.check_constraint "amount_yen >= 0", name: "chk_amount_nonneg"
+  end
 
   create_table "time_entries", force: :cascade do |t|
     t.integer "user_id", null: false

--- a/spec/requests/sales_spec.rb
+++ b/spec/requests/sales_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Sales", type: :request do
+  let(:tz) { ActiveSupport::TimeZone["Asia/Tokyo"] }
+  let(:date) { Date.parse("2025-09-06") }
+
+  # 管理者ユーザーをファクトリまたは直接作成
+  let!(:admin) do
+    User.find_or_create_by!(email: "admin@example.com") do |u|
+      u.password = "adminpass"
+      u.role = :admin
+      u.base_hourly_wage = 1200
+      u.name = "管理者"
+    end
+  end
+
+  # ログイン用トークンを取得
+  def token_for(email:, password:)
+    post "/auth/login", params: { email:, password: }
+    JSON.parse(response.body)["token"]
+  end
+
+  describe "GET /v1/sales" do
+    let(:auth_headers) { { "Authorization" => "Bearer #{token_for(email: admin.email, password: 'adminpass')}" } }
+
+    context "when a sale record exists for the date" do
+      # テスト用の売上レコードを作成
+      let!(:sale) { Sale.create!(date: date, amount_yen: 50000, note: "新商品セール") }
+
+      it "returns the sale record for the date" do
+        get "/v1/sales", params: { date: date.to_s }, headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+
+        expect(body["date"]).to eq(date.to_s)
+        expect(body["amount_yen"]).to eq(50000)
+        expect(body["note"]).to eq("新商品セール")
+      end
+    end
+
+    context "when a sale record does not exist for the date" do
+      it "returns a record with amount_yen as nil" do
+        get "/v1/sales", params: { date: date.to_s }, headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+
+        expect(body["date"]).to eq(date.to_s)
+        expect(body["amount_yen"]).to be_nil
+        expect(body["note"]).to be_nil
+      end
+    end
+
+    context "when the date parameter is invalid" do
+      it "returns a bad request error" do
+        get "/v1/sales", params: { date: "invalid-date" }, headers: auth_headers
+
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("invalid_date_format")
+      end
+    end
+  end
+
+  describe "PUT /v1/sales" do
+    let(:auth_headers) { { "Authorization" => "Bearer #{token_for(email: admin.email, password: 'adminpass')}" } }
+
+    context "when creating a new sale record (upsert)" do
+      it "creates a new sale record" do
+        put "/v1/sales", params: { date: date.to_s, amount_yen: 75000, note: "キャンペーン" }, headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+
+        expect(body["date"]).to eq(date.to_s)
+        expect(body["amount_yen"]).to eq(75000)
+        expect(body["note"]).to eq("キャンペーン")
+
+        # データベースにレコードが作成されたことを確認
+        expect(Sale.find_by(date: date)).to be_present
+      end
+    end
+
+    context "when updating an existing sale record (upsert)" do
+      let!(:existing_sale) { Sale.create!(date: date, amount_yen: 10000, note: "既存データ") }
+
+      it "updates the existing sale record" do
+        put "/v1/sales", params: { date: date.to_s, amount_yen: 20000, note: "更新データ" }, headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+
+        expect(body["amount_yen"]).to eq(20000)
+        expect(body["note"]).to eq("更新データ")
+
+        # データベースのレコードが更新されたことを確認
+        updated_sale = Sale.find_by(date: date)
+        expect(updated_sale.amount_yen).to eq(20000)
+      end
+    end
+
+    context "when amount_yen is invalid" do
+      it "returns an unprocessable_entity error" do
+        put "/v1/sales", params: { date: date.to_s, amount_yen: -100, note: "マイナス金額" }, headers: auth_headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = JSON.parse(response.body)
+        expect(body["errors"]).to include("Amount yen must be greater than or equal to 0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
日別売上の保存・取得機能を実装しました（管理者専用）。

### エンドポイント
- `GET /v1/sales?date=YYYY-MM-DD`
  - その日の売上を取得（未登録時は `amount_yen: null`）
- `PUT /v1/sales?date=YYYY-MM-DD`
  - `amount_yen`（必須, 0以上）, `note`（任意）で upsert

### スキーマ
- `sales(date:date uniq, amount_yen:int>=0, note:string)`
- DB制約：`amount_yen >= 0`、`date` unique

### 認可
- 認証必須、**admin のみ**

### 互換性
- 既存APIへの影響なし
