### PR TITLE
feat(ratio): add daily ratio API combining sales and total wages

### DIFF
--- a/app/controllers/l_ratio_controller.rb
+++ b/app/controllers/l_ratio_controller.rb
@@ -1,0 +1,61 @@
+class LRatioController < ApplicationController
+  before_action :authenticate!
+  before_action :require_admin!
+
+  def daily
+    date = parse_date!(params[:date])
+    return if performed?
+    sales = Sale.find_by(date: date)&.amount_yen
+    total_wage = compute_total_wage(date)
+
+    lratio_val = if sales.nil? || sales.to_i <= 0
+      nil
+    else
+      (total_wage.to_f / sales.to_f).round(4)
+    end
+
+    render json: {
+      date: date.to_s,
+      daily_sales: sales,
+      total_daily_wage: total_wage,
+      lratio: lratio_val
+    }
+  end
+
+  private
+
+  def parse_date!(date_str)
+    Date.parse(date_str.presence || Date.today.to_s)
+  rescue ArgumentError
+    render json: { error: "invalid_date_format" }, status: :bad_request
+  end
+
+  def compute_total_wage(date)
+    tz = ActiveSupport::TimeZone["Asia/Tokyo"]
+    day_start = tz.parse("#{date} 00:00")
+    day_end = tz.parse("#{date} 23:59:59") + 1.second
+    range = day_start...(day_end - 1.second)
+
+    user_ids = TimeEntry.where(happened_at: range).distinct.pluck(:user_id)
+    users = User.where(id: user_ids).select(:id, :base_hourly_wage)
+    users_by_id = users.index_by(&:id)
+
+    total = 0
+    user_ids.each do |uid|
+      user = users_by_id[uid]
+      next unless user
+
+      attendance_summary = Attendance::Calculator.summarize_day(user_id: uid, date: date)
+      next if attendance_summary.work_minutes.to_i <= 0
+
+      base = user.base_hourly_wage.to_i
+      wage = ::Payroll::Calculator.daily_wage(
+        base: base,
+        work_minutes: attendance_summary.work_minutes,
+        night_minutes: attendance_summary.night_minutes
+      )
+      total += wage
+    end
+    total
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,7 @@ Rails.application.routes.draw do
 
     get "sales", to: "sales#show"
     put "sales", to: "sales#upsert"
+
+    get "l_ratio/daily", to: "l_ratio#daily"
   end
 end

--- a/spec/requests/lratio_daily_spec.rb
+++ b/spec/requests/lratio_daily_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Ratio::Daily", type: :request do
+  let(:tz) { ActiveSupport::TimeZone["Asia/Tokyo"] }
+  let(:date) { Date.parse("2025-09-06") }
+
+  let!(:admin) do
+    User.find_or_create_by!(email: "admin@example.com") do |u|
+      u.password = "adminpass"
+      u.role = :admin
+      u.base_hourly_wage = 1200
+      u.name = "管理者"
+    end
+  end
+
+  let!(:emp) do
+    User.find_or_create_by!(email: "emp@example.com") do |u|
+      u.password = "emppass"
+      u.role = :employee
+      u.base_hourly_wage = 1000
+      u.name = "従業員"
+    end
+  end
+
+  def token_for(email:, password:)
+    post "/auth/login", params: { email:, password: }
+    JSON.parse(response.body)["token"]
+  end
+
+  before { TimeEntry.destroy_all }
+
+  it "returns ratio when sales exists" do
+    # 労働 2h（通常）→ wage = 1000*2 = 2000
+    TimeEntry.create!(user_id: emp.id, kind: :clock_in,  happened_at: tz.parse("#{date} 09:00"), source: "spec")
+    TimeEntry.create!(user_id: emp.id, kind: :clock_out, happened_at: tz.parse("#{date} 11:00"), source: "spec")
+    Sale.create!(date: date, amount_yen: 10000)
+
+    t = token_for(email: "admin@example.com", password: "adminpass")
+    get "/v1/l_ratio/daily", params: { date: date.to_s }, headers: { "Authorization" => "Bearer #{t}" }
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["total_daily_wage"]).to eq(2000)
+    expect(body["daily_sales"]).to eq(10000)
+    expect(body["lratio"]).to eq(0.2)
+  end
+
+  it "ratio is null when sales missing" do
+    t = token_for(email: "admin@example.com", password: "adminpass")
+    get "/v1/l_ratio/daily", params: { date: date.to_s }, headers: { "Authorization" => "Bearer #{t}" }
+    body = JSON.parse(response.body)
+    expect(body["lratio"]).to be_nil
+  end
+end


### PR DESCRIPTION
## 概要
日別の **売上対人件費比率** を返す“即時計算”APIを追加しました（保存なし）。

### エンドポイント
- `GET /v1/ratio/daily?date=YYYY-MM-DD`（adminのみ）
  - `sales_yen`: 売上（未登録なら null）
  - `total_wage_yen`: 当日の人件費合計
  - `ratio`: `total_wage / sales` を小数で返す（売上ゼロ/未登録なら null）

### 仕様
- 人件費の合計は Loop13 と同じ式で算出：
  - `wage = base * (work/60) + base*0.25 * (night/60)`（1円未満切捨て）
  - 実働0分は除外
- 売上は `sales` テーブルから当日分を参照

### 認可
- 認証必須、**admin のみ**

### マイグレーション
- なし

### 動作確認
```bash
ADMIN=$(curl -s -X POST $BASE/auth/login -d 'email=admin@example.com&password=adminpass' | jq -r .token)
curl -X PUT -H "Authorization: Bearer $ADMIN" -d "amount_yen=123456" "$BASE/v1/sales?date=2025-09-06"
curl -H "Authorization: Bearer $ADMIN" "$BASE/v1/ratio/daily?date=2025-09-06"