### PR TITLE
is_activeを削除し，enumでステータスを管理するように変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,13 +5,14 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = User.where(is_active: true).order(:id)
+    @users = User.status_active.order(:id)
     render json: @users.as_json(only: [ :id, :name, :email, :role, :base_hourly_wage ]), status: :ok
   end
 
   # POST /users/signup
   def signup
     user = User.new(user_params)
+    user.status = :pending
     if user.save
       render json: { message: "ユーザー登録の申請を受け付けました。管理者の承認をお待ちください。" }, status: :created
     else
@@ -21,16 +22,16 @@ class UsersController < ApplicationController
 
   # GET /users/pending
   def pending
-    @pending_users = User.where(is_active: false)
+    @pending_users = User.status_pending
     render json: @pending_users, status: :ok
   end
 
   # PATCH /users/:id/approve
   def approve
-    if @user.update(is_active: true, role: params[:role], base_hourly_wage: params[:base_hourly_wage])
+    if @user.update(role: params[:role], base_hourly_wage: params[:base_hourly_wage], status: :active)
       render json: { message: "#{@user.name}さんを承認しました。" }, status: :ok
     else
-      render json: { error: user.errors.full_messages }, status: :unprocessable_entity
+      render json: { error: @user.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
@@ -45,14 +46,17 @@ class UsersController < ApplicationController
 
   # DELETE /users/:id
   def destroy
-    @user.destroy
-    render json: { message: "#{@user.name}さんを削除しました。" }, status: :ok
+    if @user.status_deleted!
+      render json: { message: "#{@user.name}さんを削除しました。" }, status: :ok
+    else
+      render json: { error: @user.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   private
 
   def user_update_params
-    params.require(:user).permit(:role, :base_hourly_wage).merge(is_active: true)
+    params.require(:user).permit(:role, :base_hourly_wage)
   end
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,7 @@ class User < ApplicationRecord
   has_secure_password
   enum :role, { employee: 0, admin: 1 }
 
+  enum :status, { pending: 0, active: 1, deleted: 2 }, _prefix: true
+
   validates :base_hourly_wage, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/db/migrate/20250917052325_remove_is_active_and_add_status_to_users.rb
+++ b/db/migrate/20250917052325_remove_is_active_and_add_status_to_users.rb
@@ -1,0 +1,9 @@
+class RemoveIsActiveAndAddStatusToUsers < ActiveRecord::Migration[8.0]
+  def change
+    # is_activeカラムを削除
+    remove_column :users, :is_active, :boolean
+
+    # statusカラムを追加 (0: pending, 1: active, 2: deleted)
+    add_column :users, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_15_023136) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_17_052325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_15_023136) do
     t.string "password_digest"
     t.integer "role", default: 0, null: false
     t.integer "base_hourly_wage", default: 0, null: false
-    t.boolean "is_active", default: false, null: false
+    t.integer "status", default: 0, null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["role"], name: "index_users_on_role"
     t.check_constraint "base_hourly_wage >= 0", name: "base_hourly_wage_non_negative"


### PR DESCRIPTION
ユーザーの理論削除をするために，ユーザーのステータスをenumで管理するように変更した
将来休職などのステータスを追加することになっても対応可能．
